### PR TITLE
Correct command for running tool

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -72,7 +72,7 @@ dotnet tool install --global fsix.web
 Then, just run
 
 ```
-dotnet fsix #or fsix-web
+fsix #or fsix-web
 ```
 in the root dir of your project
 


### PR DESCRIPTION
The documentations says to run command you need to do `dotnet fsix` but running in that way will give you an error. The correct way is to simplty run `fsix` or `fsix-web`